### PR TITLE
Remove env token

### DIFF
--- a/.github/workflows/update-wp.yml
+++ b/.github/workflows/update-wp.yml
@@ -11,8 +11,6 @@ permissions:
 jobs:
   update-wordpress:
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2

--- a/.github/workflows/update-wp.yml
+++ b/.github/workflows/update-wp.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   update-wordpress:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2

--- a/.github/workflows/update-wp.yml
+++ b/.github/workflows/update-wp.yml
@@ -26,8 +26,6 @@ jobs:
           ./private/scripts/maybe-add-wp-cli.sh
       - name: Check GH User
         run: |
-          gh auth login --with-token
-          gh auth status
           gh api user
       - name: Check for WordPress updates
         run: |

--- a/.github/workflows/update-wp.yml
+++ b/.github/workflows/update-wp.yml
@@ -24,6 +24,7 @@ jobs:
           ./private/scripts/maybe-add-wp-cli.sh
       - name: Check GH User
         run: |
+          gh auth login
           gh auth status
           gh api user
       - name: Check for WordPress updates

--- a/.github/workflows/update-wp.yml
+++ b/.github/workflows/update-wp.yml
@@ -26,7 +26,7 @@ jobs:
           ./private/scripts/maybe-add-wp-cli.sh
       - name: Check GH User
         run: |
-          gh auth login
+          gh auth login --with-token
           gh auth status
           gh api user
       - name: Check for WordPress updates

--- a/.github/workflows/update-wp.yml
+++ b/.github/workflows/update-wp.yml
@@ -11,8 +11,6 @@ permissions:
 jobs:
   update-wordpress:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
@@ -24,9 +22,6 @@ jobs:
       - name: Install WP-CLI
         run: |
           ./private/scripts/maybe-add-wp-cli.sh
-      - name: Check GH User
-        run: |
-          gh api user
       - name: Check for WordPress updates
         run: |
           # Check WP

--- a/.github/workflows/update-wp.yml
+++ b/.github/workflows/update-wp.yml
@@ -12,7 +12,7 @@ jobs:
   update-wordpress:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.API_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2


### PR DESCRIPTION
This removes the GH_TOKEN env variable (unneeded for what we're using `gh` for) as well as the Auth check (which is unnecessary because `gh api user` requires higher auth than `gh pr create` which is the only thing we really need).